### PR TITLE
fix: restore release-please tag detection

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "ursa-android",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "include-component-in-tag": false,


### PR DESCRIPTION
Remove the obsolete package-name option so release-please v17 matches the existing component-free vX.Y.Z tags and can publish the merged 1.2.1 release candidate.