### PR TITLE
fix: align release-please component history

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "package-name": "ursa-android",
+      "component": "ursa-android",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "include-component-in-tag": false,


### PR DESCRIPTION
Declare the ursa-android release component explicitly while retaining component-free vX.Y.Z tags. This matches the component recorded by prior releases and lets release-please publish the merged 1.2.1 candidate.