### PR TITLE
docs(repo): update community links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions and ideas
-    url: https://github.com/AstorisTheBrave/ursa-android/discussions
+    url: https://github.com/greyfoundry/ursa-android/discussions
     about: Ask a question or discuss an idea in Discussions before opening an issue.
   - name: Security vulnerability
-    url: https://github.com/AstorisTheBrave/ursa-android/security/policy
+    url: https://github.com/greyfoundry/ursa-android/security/policy
     about: Please report vulnerabilities privately, not via public issues.
   - name: Uptime Kuma (server) issues
     url: https://github.com/louislam/uptime-kuma/issues


### PR DESCRIPTION
## Summary

- point Discussions to the Greyfoundry repository
- point the security-policy link to the Greyfoundry repository

## Validation

- Discussions are enabled on the destination repository
- the repository tracks SECURITY.md
- git diff --check