### PR TITLE
docs(network): verify Kuma 2.5.3 compatibility

### DIFF
--- a/app/src/main/java/dev/astoris/ursa/core/network/KumaParse.kt
+++ b/app/src/main/java/dev/astoris/ursa/core/network/KumaParse.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * Pure normalization of Uptime Kuma wire payloads into domain models. Kept free of
  * Android/Socket.IO types (operates on kotlinx JsonObject) so it is unit-testable on
- * the JVM. Shapes verified live against Kuma 2.5.0 - see docs/references/uptime-kuma-api.mdx.
+ * the JVM. Shapes verified live against Kuma 2.5.3 - see docs/references/uptime-kuma-api.mdx.
  */
 object KumaParse {
 

--- a/app/src/main/java/dev/astoris/ursa/core/network/StatusPageClient.kt
+++ b/app/src/main/java/dev/astoris/ursa/core/network/StatusPageClient.kt
@@ -18,7 +18,7 @@ import kotlinx.serialization.json.Json
 /**
  * Fetches a public Uptime Kuma status page (no auth). Combines the config endpoint
  * (groups + monitors) with the heartbeat endpoint (latest status + 24h uptime) into
- * a flat [StatusPageView]. Shapes verified against Kuma 2.5.0.
+ * a flat [StatusPageView]. Shapes verified against Kuma 2.5.3.
  */
 class StatusPageClient {
 

--- a/docs/modules/network.mdx
+++ b/docs/modules/network.mdx
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-08-21
+last-updated: 2026-08-25
 owner: astoris
 status: stable
 ---
@@ -42,7 +42,7 @@ here so the rest of the app sees clean domain models.
 ## gotchas
 
 - Positional events (`heartbeatList`, `avgPing`, `uptime`, `certInfo`) are read from
-  `args[]` directly. Kuma 2.5.0 serializes their monitor IDs as strings, normalized
+  `args[]` directly. Kuma 2.5.3 serializes their monitor IDs as strings, normalized
   by `KumaParse.positionalInt`; object events go through `jsonAt()` → kotlinx →
   `KumaParse`.
 - `heartbeat` event is camelCase; `getMonitorBeats` rows are snake_case - two

--- a/docs/modules/push.mdx
+++ b/docs/modules/push.mdx
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-07-04
+last-updated: 2026-08-25
 owner: astoris
 status: in-flux
 ---
@@ -49,6 +49,10 @@ connection: push works while the app is closed.
   notification (logs a warning) if it isn't granted. `PushScreen` requests it.
 - ntfy endpoints need `?up=1` appended so ntfy forwards Kuma's raw bytes - surfaced
   as a hint on the endpoint screen.
+- Kuma 2.5.1's Pinglet and SMS Gateway additions are separate outbound providers;
+  the existing Webhook provider still sends the same `{ heartbeat, monitor, msg }`
+  body, verified live through Kuma 2.5.3. URSA should keep the provider-neutral
+  Webhook to UnifiedPush path rather than depend on a third-party provider.
 - Same monitor id reuses its notification id, so a new status replaces the old one.
 - Notification content and monitor actions use immutable PendingIntents with explicit
   app-owned activity/receiver components.

--- a/docs/references/uptime-kuma-api.mdx
+++ b/docs/references/uptime-kuma-api.mdx
@@ -1,17 +1,17 @@
 ---
-last-updated: 2026-08-21
+last-updated: 2026-08-25
 owner: astoris
 status: stable
-source: verified from Uptime Kuma 2.5.0 source and a live 2.5.0 container
+source: verified from Uptime Kuma 2.5.3 source and a live 2.5.3 container
 ---
 
 ## what this is
 
 How URSA talks to an Uptime Kuma server. Kuma has no stable public API - it's a
 Socket.IO app plus a few unauthenticated REST endpoints for public status pages.
-Everything below was checked against tag `2.5.0` (`d9a60df`) and captured from
-the official `louislam/uptime-kuma:2.5.0` image (digest
-`sha256:a8610b3b4c38077922ba51b036691e06887d7cefd91fe620fd3d6d23d03dc240`).
+Everything below was rechecked against tag `2.5.3` (`1f0755f`) and captured from
+the official `louislam/uptime-kuma:2.5.3` image (digest
+`sha256:3e24e96c89efff0e3a4b0698cbdd36c15ad3022371db57166e5588853002ee5c`).
 Sanitized raw captures and the complete source-derived event/route inventory live
 under gitignored `docs/kuma-notes/`. Build a thin adapter around this; expect drift
 between versions.
@@ -56,6 +56,13 @@ Kuma 2.5.0 adds `ntp` and `pm2` monitor types plus the authenticated
 `getPM2ProcessList` event. Those additions do not change URSA's read,
 heartbeat-history, certificate, pause, or resume contracts.
 
+Kuma 2.5.1 adds seven outbound notification providers: SMS Gateway, ClickUp,
+TurboSMTP, BearSMS, Pinglet, Milky, and OpenWA. They do not change the Webhook
+provider payload URSA consumes. Kuma 2.5.2 fixes non-Docker installation, and
+2.5.3 corrects the published version number. Across 2.5.0 through 2.5.3, the
+source inventory remains 87 client events, 30 server emit candidates, and 33 REST
+routes; normalized live payload shapes used by URSA are unchanged.
+
 **REST (no auth - public status pages)**
 - `GET /api/status-page/<slug>` - page config, groups, monitors, incident
 - `GET /api/status-page/heartbeat/<slug>` - heartbeats + uptime
@@ -65,7 +72,7 @@ heartbeat-history, certificate, pause, or resume contracts.
 
 - **Case split**: live `heartbeat` event is camelCase; `getMonitorBeats` rows are
   snake_case. The data model must map both to one domain type.
-- **String IDs in positional events**: monitor IDs are JSON strings in live 2.5.0
+- **String IDs in positional events**: monitor IDs are JSON strings in live 2.5.3
   `heartbeatList`, `avgPing`, `uptime`, and `certInfo` emissions even though IDs
   inside object payloads are numbers. Normalize both forms at the adapter boundary.
 - **Double-encoded JSON**: notification `config` and monitor `tags` arrive as a

--- a/docs/sessions/log.mdx
+++ b/docs/sessions/log.mdx
@@ -9,6 +9,20 @@ status: stable
 The running change log across sessions - project memory over time. Append a dated
 entry every session that changes structure. Newest at top.
 
+### 2026-08-25 - Kuma 2.5.3 compatibility verification
+
+**verified**: Compared Uptime Kuma 2.5.1 through 2.5.3 release notes and source,
+then captured a fresh official 2.5.3 container. The source inventory remains 87
+client events, 30 server emit candidates, and 33 REST routes. Normalized shapes for
+every URSA-consumed event, acknowledgement, and public status-page response match
+the 2.5.0 baseline.
+
+**decision**: The seven 2.5.1 features are outbound notification providers. Pinglet
+and SMS Gateway are useful alternatives for their own clients, but do not improve
+URSA's provider-neutral Webhook to UnifiedPush flow. The Webhook payload is unchanged,
+so no compatibility code or UI change is required. Versions 2.5.2 and 2.5.3 only
+repair non-Docker packaging and published version identity respectively.
+
 ### 2026-08-24 - manual release publication
 
 **changed**: Removed Release Please and its manifest/configuration after the


### PR DESCRIPTION
## Summary
- verify URSA against Uptime Kuma 2.5.1 through 2.5.3 release source
- capture the official 2.5.3 container and compare normalized event, acknowledgement, and status-page payload shapes with the 2.5.0 baseline
- document the seven 2.5.1 outbound providers and retain URSA's provider-neutral Webhook to UnifiedPush path
- record that 2.5.2 and 2.5.3 are packaging/version corrections with no URSA API change

## Evidence
- source inventory unchanged: 87 client events, 30 server emit candidates, 33 REST routes
- normalized URSA-consumed payload shape deltas: 0
- official image `louislam/uptime-kuma:2.5.3` (`sha256:3e24e96c89efff0e3a4b0698cbdd36c15ad3022371db57166e5588853002ee5c`)

## Verification
- 44 debug unit tests, 0 failures/errors/skips
- phone debug assembly and Android lint
- Wear debug assembly